### PR TITLE
Fixing the package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/concrete.cc/jest-mock-express.git"
+    "url": "git://github.com/concrete-cc/jest-mock-express.git"
   },
   "bugs": {
     "url": "https://github.com/concrete-cc/jest-mock-express/issues"


### PR DESCRIPTION
With that url everyone can access the repo on the npm page.
