### PR TITLE
Updates jest dependency from 18.1.0 to 22.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jest": "^18.1.0"
+    "jest": "^22.0.4"
   }
 }


### PR DESCRIPTION
Updates jest dependency to a more modern version.

This is motivated by including jest-mock-express in a project with a more recent version of jest, which leads into the error "TypeError: environment.setup is not a function" which is resolved by updating jest (see https://github.com/facebook/jest/issues/5119 for more info), because this ends up resolving a version incompatibility with an indirect dependency `jest-environment-node` (more info in the linked ticket).